### PR TITLE
fix: add SPDX field in zkBesu template file

### DIFF
--- a/src/exporters/besu.java
+++ b/src/exporters/besu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys Software Inc.
+ * Copyright ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -9,7 +9,10 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
+
 package net.consensys.linea.zktracer.module.{{ module }};
 
 import com.fasterxml.jackson.annotation.JsonProperty;


### PR DESCRIPTION
Applies new copyright header in generated java besu files, required for gradle checks in linea-besu-plugin repo.