### PR TITLE
Document vector operations.

### DIFF
--- a/src/compiler/common.rs
+++ b/src/compiler/common.rs
@@ -144,6 +144,9 @@ impl std::fmt::Display for Builtin {
             match self {
                 Builtin::Len => "len",
                 Builtin::Shift => "shift",
+                /// This represents normalisation in the presence of
+                /// field agnosticity.  Perhaps it might be considered
+                /// "vector normalisation"?
                 Builtin::NormFlat => "~>>",
                 Builtin::If => "if?",
             }
@@ -158,8 +161,11 @@ pub enum Intrinsic {
     Add,
     Sub,
     Mul,
+    /// Vector addition is required for field agnosticity.
     VectorAdd,
+    /// Vector subtraction is required for field agnosticity.    
     VectorSub,
+    /// Vector multiplication is required for field agnosticity.        
     VectorMul,
     Exp,
     Neg,


### PR DESCRIPTION
These operations are required for field agnosticity.  That is, where a virtual field is spread across several actual fields (i.e. because its bitwidth is larger than what is provided by the prime field).