### PR TITLE
Binary Output Serialisation to JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ exporters = ["dep:handlebars"]
 inspector = ["dep:crossterm", "dep:ratatui", "dep:tui-textarea", "cli"]
 postgres = ["dep:postgres"]
 sqlite = ["dep:rusqlite"]
+json-bin = []
 
 [package.metadata.release]
 tag-prefix = ""


### PR DESCRIPTION
This now enables support for binary output serialisation.  However, at this stage, it remains hidden behind a feature flag.  The reason for this is simply that it currently alter's output in the non-JSON path as well.  The need for this arose from the mechanism required for serialising handles.