### PR TITLE
Improved translation for `NORM(e)` #91

### DIFF
--- a/src/transformer/inverses.rs
+++ b/src/transformer/inverses.rs
@@ -39,7 +39,11 @@ impl Node {
                         // Intrinsic::Inv should never have more than one argument
                         assert!(args.len() == 1);
                         let arg = &args[0];
-                        if true {
+                        if arg.t().is_binary() {
+                            // No need for a normalised column if its
+                            // already binary.
+                            *self = arg.clone();
+                        } else if true {
                             let module = get_module(&arg.dependencies());
                             let inverted_handle =
                                 Handle::new(module, expression_to_name(arg, "INV"));


### PR DESCRIPTION
This applies a patch suggested by Franklin for improving the translation of `NORM(e)` terms.  Specifically, when `e` is known to be `binary` then we actually don't need to create an inverse column.  Instead, we can use `e` directly as we already know its normalised.