### PR TITLE
Display `:bytes` in big endian

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -455,7 +455,7 @@ impl Pretty for Value {
                 Base::Hex => format!("0x{}", i.to_str_radix(16)),
                 Base::Bin | Base::Bool | Base::Loob => i.to_str_radix(2),
                 Base::Bytes => i
-                    .to_bytes_le()
+                    .to_bytes_be()
                     .1
                     .iter()
                     .map(|b| format!("{b:0>2x}"))


### PR DESCRIPTION
Previously, columns marked as `:bytes` were displayed in the inspector in _little endian_ form.  However, this was awkward for comparing with normal hexadecimal values.  For example, `0x1023` was shown as `23 10`.

Therefore, have changed the display option to show `:bytes` in big endian notation.  Thus, the example above shows as `10 23`.