### PR TITLE
Fix Default Base for Interleaved Constraints

### DIFF
--- a/src/compiler/parser/parser.rs
+++ b/src/compiler/parser/parser.rs
@@ -207,7 +207,7 @@ impl std::convert::TryInto<DisplayableColumn> for ColumnAttributes {
         }
         Ok(DisplayableColumn {
             name: self.name,
-            base: self.base.get().cloned().unwrap_or(Base::Dec),
+            base: self.base.get().cloned().unwrap_or(Base::Hex),
         })
     }
 }


### PR DESCRIPTION
This updates the default base for the column(s) arising from an interleaved constraint to be hexadecimal rather than decimal.  This now follows the convention used in e.g. `defcolumns` which also defaults to hex.