### PR TITLE
Update testing framework to support padding

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -443,6 +443,12 @@ pub fn fill_traces_from_json(
                     // Atomic columns are always padded with zeroes, so there is
                     // no need to trigger a more complex padding system.
                     if !keep_raw && xs.len() < module_min_len {
+                        trace!(
+                            "padding {} to min module length ({} => {})",
+                            handle,
+                            xs.len(),
+                            module_min_len
+                        );
                         xs.reverse();
                         xs.resize_with(module_min_len, || {
                             padding_value.clone().unwrap_or_default()

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -19,6 +19,14 @@ impl Model {
     const MIN_ELEMENT: isize = -1;
     const MAX_ELEMENT: isize = 1;
 
+    pub fn new(
+        name: &'static str,
+        cols: &'static [&'static str],
+        oracle: fn(data: &Trace) -> bool,
+    ) -> Self {
+        Self { name, cols, oracle }
+    }
+
     /// Generate all traces matching the model configuration upto
     /// length `n`, and split them into the `accepts` and `rejects`.
     /// The former are those traces which are expected to pass, whilst
@@ -82,15 +90,21 @@ struct Trace {
     /// The trace data, whose length must be divisible by `width`.
     /// Data is stored one column after another.
     data: Vec<isize>,
+    /// Identifies how many rows of padding come at the beginning.
+    padding: usize,
 }
 
 impl Trace {
     pub fn new(cols: &'static [&'static str], data: Vec<isize>) -> Self {
-        Self { cols, data }
+        Self {
+            cols,
+            data,
+            padding: 1,
+        }
     }
     /// Determine how many rows of data there are.
     pub fn height(&self) -> usize {
-        self.data.len() / self.width()
+        self.padding + (self.data.len() / self.width())
     }
 
     /// Determine how many columns of data there are.
@@ -98,25 +112,47 @@ impl Trace {
         self.cols.len()
     }
 
+    /// Access the data for a given column based on its name.
+    pub fn col<'a>(&'a self, name: &str) -> Column<'a> {
+        for i in 0..self.cols.len() {
+            if self.cols[i] == name {
+                return Column {
+                    data: self.get(i),
+                    padding: self.padding,
+                };
+            }
+        }
+        panic!("unknown column: {name}");
+    }
+
     /// Access the data for a given column.
-    pub fn get(&self, col: usize) -> &[isize] {
-        let n = self.height();
+    pub fn get<'a>(&'a self, col: usize) -> &[isize] {
+        let n = self.data.len() / self.width();
         let start = col * n;
         let end = (col + 1) * n;
         &self.data[start..end]
     }
 }
 
-impl Index<&str> for Trace {
-    type Output = [isize];
+/// Represents a single column which can contain zero (or more) rows
+/// of padding at the beginning.
+struct Column<'a> {
+    // The raw data underlying this column
+    data: &'a [isize],
+    // The number of rows of passing which are assumed to be prepended
+    // onto this column.
+    padding: usize,
+}
 
-    fn index(&self, index: &str) -> &Self::Output {
-        for i in 0..self.cols.len() {
-            if self.cols[i] == index {
-                return self.get(i);
-            }
+impl<'a> Index<usize> for Column<'a> {
+    type Output = isize;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if index < self.padding {
+            &0
+        } else {
+            &self.data[index - self.padding]
         }
-        panic!("unknown column: {index}");
     }
 }
 
@@ -127,7 +163,7 @@ impl Index<&str> for Trace {
 /// The master list of active models.  Tests will be automatically
 /// generated for each item in this list.
 static MODELS: &[Model] = &[
-    // Model {name: "arrays_1", cols: &["A", "B_1","B_2","B_3"], oracle: arrays_1_oracle},
+    //Model {name: "arrays_1", cols: &["A", "B_1","B_2","B_3"], oracle: arrays_1_oracle},
     Model {
         name: "iszero",
         cols: &["A", "B"],
@@ -138,7 +174,11 @@ static MODELS: &[Model] = &[
         cols: &["A", "B"],
         oracle: shift_1_oracle,
     },
-    //Model {name: "shift_2", cols: &["A", "B"], oracle: shift_2_oracle} problem with padding
+    Model {
+        name: "shift_2",
+        cols: &["A", "B"],
+        oracle: shift_2_oracle,
+    },
     Model {
         name: "shift_3",
         cols: &["A", "B"],
@@ -151,11 +191,12 @@ static MODELS: &[Model] = &[
 // ===================================================================
 
 fn arrays_1_oracle(tr: &Trace) -> bool {
+    let (A, B_1, B_2, B_3) = (tr.col("A"), tr.col("B_1"), tr.col("B_2"), tr.col("B_3"));
+
     for k in 0..tr.height() {
-        let c1 = tr["A"][k] == 0 || (tr["B_1"][k] + 1 == tr["B_2"][k]);
-        let c2 = tr["A"][k] == 0 || (tr["B_2"][k] + 2 == tr["B_3"][k]);
-        let c3 =
-            tr["A"][k] == tr["B_1"][k] || tr["A"][k] == tr["B_2"][k] || tr["A"][k] == tr["B_3"][k];
+        let c1 = A[k] == 0 || (B_1[k] + 1 == B_2[k]);
+        let c2 = A[k] == 0 || (B_2[k] + 2 == B_3[k]);
+        let c3 = A[k] == B_1[k] || A[k] == B_2[k] || A[k] == B_3[k];
         if !(c1 && c2 && c3) {
             return false;
         }
@@ -163,26 +204,30 @@ fn arrays_1_oracle(tr: &Trace) -> bool {
     true
 }
 
-// ===================================================================
-// IsZero
-// ===================================================================
+// // ===================================================================
+// // IsZero
+// // ===================================================================
 
 fn iszero_oracle(tr: &Trace) -> bool {
+    let (A, B) = (tr.col("A"), tr.col("B"));
+
     for k in 0..tr.height() {
-        if tr["B"][k] != 0 && tr["A"][k] == 0 {
+        if B[k] != 0 && A[k] == 0 {
             return false;
         }
     }
     true
 }
 
-// ===================================================================
-// Shift
-// ===================================================================
+// // ===================================================================
+// // Shift
+// // ===================================================================
 
 fn shift_1_oracle(tr: &Trace) -> bool {
+    let (A, B) = (tr.col("A"), tr.col("B"));
+
     for k in 0..tr.height() {
-        let c1 = k + 1 >= tr.height() || tr["B"][k] == 0 || tr["A"][k] + 1 == tr["A"][k + 1];
+        let c1 = k + 1 >= tr.height() || B[k] == 0 || A[k] + 1 == A[k + 1];
         if !c1 {
             return false;
         }
@@ -191,8 +236,10 @@ fn shift_1_oracle(tr: &Trace) -> bool {
 }
 
 fn shift_2_oracle(tr: &Trace) -> bool {
+    let (A, B) = (tr.col("A"), tr.col("B"));
+
     for k in 0..tr.height() {
-        let c1 = k == 0 || tr["B"][k] == 0 || tr["B"][k] == tr["A"][k - 1];
+        let c1 = k == 0 || B[k] == 0 || B[k] == A[k - 1];
         if !c1 {
             return false;
         }
@@ -201,8 +248,10 @@ fn shift_2_oracle(tr: &Trace) -> bool {
 }
 
 fn shift_3_oracle(tr: &Trace) -> bool {
+    let (A, B) = (tr.col("A"), tr.col("B"));
+
     for k in 0..tr.height() {
-        let c1 = k + 2 >= tr.height() || tr["B"][k] == 0 || tr["B"][k] == tr["A"][k + 2];
+        let c1 = k + 2 >= tr.height() || B[k] == 0 || B[k] == A[k + 2];
         if !c1 {
             return false;
         }


### PR DESCRIPTION
This updates the testing framework to support padding.  In particular, it now always padds the first row with zeros.  At some point, we'll need to support minimum length padding based on e.g. range constraints.