### PR TITLE
Fix for `eq!` typing in `stdlib.lisp`

### DIFF
--- a/src/stdlib.lisp
+++ b/src/stdlib.lisp
@@ -34,7 +34,7 @@
 
 (defpurefun ((not :binary@bool :force) (x :binary)) (- 1 x))
 
-(defpurefun ((eq! :binary@loob :force) x y) (~>> (-. x y)))
+(defpurefun ((eq! :@loob :force) x y) (~>> (-. x y)))
 (defpurefun ((neq! :binary@loob :force) x y) (not (~ (eq! x y))))
 (defunalias = eq!)
 


### PR DESCRIPTION
This puts through a simple fix for the standard library.