### PR TITLE
Optimise spillage by removing `future_spilling()`

### DIFF
--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -852,7 +852,7 @@ impl ConstraintSet {
             .filter_map(|c| match c {
                 Computation::Composite { target, exp } => {
                     if target.as_handle().module == m {
-                        Some(exp.past_spill().abs().max(exp.future_spill().abs()))
+                        Some(exp.past_spill().abs())
                     } else {
                         None
                     }
@@ -862,7 +862,7 @@ impl ConstraintSet {
             .chain(self.constraints.iter().filter_map(|c| match c {
                 Constraint::Vanishes { handle, expr, .. } => {
                     if handle.module == m {
-                        Some(expr.past_spill().abs().max(expr.future_spill().abs()))
+                        Some(expr.past_spill().abs())
                     } else {
                         None
                     }

--- a/src/compiler/node.rs
+++ b/src/compiler/node.rs
@@ -498,23 +498,6 @@ impl Node {
             .unwrap_or(0)
     }
 
-    /// Compute the maximum future (positive) shift coefficient in the AST rooted at `self`
-    pub fn future_spill(&self) -> isize {
-        self.leaves()
-            .iter()
-            .filter_map(|n| match n.e() {
-                Expression::Column { shift, .. } | Expression::ExoColumn { shift, .. } => {
-                    Some(*shift as isize)
-                }
-                Expression::ArrayColumn { .. } => unreachable!(),
-                _ => None,
-            })
-            .filter(|x| *x > 0)
-            .max()
-            .unwrap_or(0)
-            .max(0)
-    }
-
     // TODO: replace with a generic map()
     pub fn add_id_to_handles(&mut self, set_id: &dyn Fn(&mut ColumnRef)) {
         match self.e_mut() {

--- a/src/exporters/debugger.rs
+++ b/src/exporters/debugger.rs
@@ -414,7 +414,7 @@ fn render_spilling_toml(cs: &ConstraintSet) {
         // Convert name to screaming snake case.
         let name = module.to_case(Case::UpperSnake);
         //
-        println!("{:>10} = {:>4}", name.blue().bold(), spilling);
+        println!("{:>10} = {:>4}", name, spilling);
     }
 }
 


### PR DESCRIPTION
This prevents "future" or positive spillage from being reported as spillage.  In essence, this feature is removed completely.