### PR TITLE
Fix #158

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -190,16 +190,9 @@ pub fn parse_binary_trace(tracefile: &str, cs: &mut ConstraintSet, keep_raw: boo
                             )
                             .ok_or_else(|| anyhow!("error reading {}th element", i))
                             .and_then(|bs| {
-                                // Decode big integer from bytes in big endian form.
-                                let bigint = CValue::big_int(BigInt::from_bytes_be(Sign::Plus, bs));
-                                // Validate this value against its declared type.
-                                let CValue::BigInt(bi) = magma.rm().validate(bigint)? else {
-                                    // Should be unreachable, since we know its a big integer.
-                                    unreachable!()
-                                };
-                                // Final checks (such as whether it fits into a native field).
-                                CValue::try_from(bi)
+                                CValue::try_from(BigInt::from_bytes_be(Sign::Plus, bs))
                                     .with_context(|| anyhow!("while parsing {}th element", i))
+                                    .and_then(|x| magma.rm().validate(x))
                             })
                             .with_context(|| anyhow!("reading {}th element", i))
                     }


### PR DESCRIPTION
This puts through a fix for validation of imported values when `native` fields are being used.  The issue is that validation was being performed _after_ conversion into the native field (when this was selected via the `-N` cli switch).  Unfortunately, validation at that point cannot work because every field value is assumed to require `254` bits.