### PR TITLE
Fix Spilling Computation for Constant Expressions

### DIFF
--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -886,7 +886,7 @@ impl ConstraintSet {
         self.columns.spilling.get(m).cloned()
     }
 
-    fn compute_spillings(&mut self) {
+    pub fn compute_spillings(&mut self) {
         let all_modules = self.columns.modules();
         for m in all_modules {
             let spilling = self.compute_spilling(&m);

--- a/src/transformer.rs
+++ b/src/transformer.rs
@@ -130,6 +130,7 @@ pub(crate) fn expand_to(
     }
 
     cs.convert_refs_to_ids()?;
+    cs.compute_spillings();
     cs.validate()
 }
 


### PR DESCRIPTION
This puts a preliminary cut for two specific fixes:

* Firstly, this now recomputes spilling information after expansion.
* Secondly, this puts through a fix related to constant expressions being used in lookups.

There are issues though.  Firstly, this completes in a few seconds:

```
corset -vvvv compute -eeeeN --auto-constraints nhood,sorts --trace issue161/1_15024091914360580354.lt --out test.json issue161/zkevm.bin
```

However, this test from @ivokub does not seems to terminate?

```rust
#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn test_corset_from_file() {
        let mut c = _corset_from_file("/home/djp/projects/zkevm/corset/issue161/zkevm.bin\
").unwrap();
        let t = _compute_trace_from_file(&mut c, "/home/djp/projects/zkevm/corset/issue16\
1/1_15024091914360580354.lt", true);
        if !t.is_ok() {
            eprintln!("{:?}", t.err());
        }
    }
}
```
I do not understand what the difference is, but will continue to investigate this.