### PR TITLE
161 bug nil spilling used in compute expression function

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -780,8 +780,12 @@ impl<'a> Iterator for ValueBackingIter<'a> {
                 }
             }
             ValueBacking::Function { f, .. } => {
-                self.i += 1;
-                f(self.i - 1, self.columns)
+                if self.i >= self.len {
+                    None
+                } else {
+                    self.i += 1;
+                    f(self.i - 1, self.columns)
+                }
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,9 @@ pub(crate) enum CompileError<'a> {
 
     #[error("column {} not found", .0.pretty())]
     NotFound(Handle),
+
+    #[error("ambiguous {} module for {} {}", .0, .1, .2.pretty())]
+    AmbiguousModule(&'static str, &'static str, Handle),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This fixes #161 and problems related to the use of constant expressions within lookups.  Specifically, such expressions were being incorrectly expanded into the `<prelude>` module.  To resolve this, the logic for determining the target (resp. source) modules for a lookup has been expanded.