### PR TITLE
fix: Incorrect typing of vector operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "corset"
-version = "9.7.10"
+version = "9.7.11"
 dependencies = [
  "anyhow",
  "ark-bls12-377",

--- a/src/compiler/common.rs
+++ b/src/compiler/common.rs
@@ -197,13 +197,11 @@ impl Intrinsic {
             Intrinsic::Add | Intrinsic::Sub | Intrinsic::Neg => {
                 // Boolean is a corner case, as it is not stable under these operations
                 let max_t = max_type(argtype)?;
-                match max_t.m().rm() {
-                    RawMagma::Binary => max_t.with_raw_magma(RawMagma::Native),
-                    _ => max_t,
-                }
+                max_t.with_raw_magma(RawMagma::Native)
             }
             Intrinsic::VectorAdd | Intrinsic::VectorSub | Intrinsic::VectorMul => {
-                super::max_type(argtype.iter())?
+                let max_t = super::max_type(argtype.iter())?;
+                max_t.with_raw_magma(RawMagma::Native)
             }
             Intrinsic::Exp => argtype[0],
             Intrinsic::Mul => argtype.iter().max().cloned().unwrap_or(Type::INFIMUM),

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,7 +594,6 @@ impl ConstraintSetBuilder {
             .map(|r| r.1),
             Either::Right(cs) => Ok(cs),
         }?;
-
         transformer::expand_to(&mut cs, self.expand_to, &self.auto_constraints)?;
         transformer::concretize(&mut cs);
         Ok(cs)


### PR DESCRIPTION
A problem was arising related to the typing of vector operations. Specifically, it was being considered that e.g. a `binary` value added to another `binary` value produced a `binary` value.  This corrects those problems, but there remain some mysteries around typing.