### PR TITLE
Fix for Singleton Reduce

### DIFF
--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -1316,8 +1316,10 @@ fn apply_form(
                 | Expression::Funcall { .. }
                 | Expression::Const(_) => panic!(),
                 Expression::List(xs) => {
-                    if xs.len() < 2 {
+		    if xs.is_empty() {
                         Ok(Some(body))
+		    } else if xs.len() == 1 {
+                        Ok(Some(xs[0].clone()))
                     } else {
                         let mut r = apply_function(
                             &f,


### PR DESCRIPTION
This fixes an issue that arises for a singleton `reduce`.  That is a `reduce` over a list with only a single element.  To be fair, this is not something that should actually be done in practice.