### PR TITLE
fix: Error when missing reduce

### DIFF
--- a/src/compiler/common.rs
+++ b/src/compiler/common.rs
@@ -183,6 +183,10 @@ impl Intrinsic {
         Ok(Node::from_expr(self.raw_call(args)))
     }
 
+    pub fn unchecked_call(self, args: &[Node]) -> Result<Node> {
+        Ok(Node::from_expr(self.raw_call(args)))
+    }
+
     pub fn raw_call(self, args: &[Node]) -> Expression {
         Expression::Funcall {
             func: self,

--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -263,9 +263,17 @@ impl FuncVerifier<Node> for Intrinsic {
             Intrinsic::Add
             | Intrinsic::Sub
             | Intrinsic::Mul
+            | Intrinsic::Neg
+            | Intrinsic::Normalize
             | Intrinsic::VectorAdd
             | Intrinsic::VectorSub
-            | Intrinsic::VectorMul => {}
+            | Intrinsic::VectorMul => {
+                for (i, arg) in args.iter().enumerate() {
+                    if arg.is_list() {
+                        bail!("unexpected list operand for {}", self.to_string())
+                    }
+                }
+            }
             Intrinsic::Begin => {
                 // TODO: maybe?
                 // if args_t
@@ -1727,7 +1735,7 @@ pub(crate) fn reduce_toplevel(
                 // controlled exceptions to the usual loobean typing rules
                 let body_type = body.t();
                 Intrinsic::Mul
-                    .call(&[persp_guard, body])
+                    .unchecked_call(&[persp_guard, body])
                     .with_context(|| anyhow!("constraint {}", name))?
                     .with_type(body_type)
             } else {

--- a/src/compiler/node.rs
+++ b/src/compiler/node.rs
@@ -371,6 +371,18 @@ impl Node {
     pub fn is_exocolumn(&self) -> bool {
         matches!(self.e(), Expression::ExoColumn { .. })
     }
+    /// Determine whether this expression is a list or not.
+    pub fn is_list(&self) -> bool {
+        match self.e() {
+            // Obvious fails
+            Expression::List(_) => true,
+            Expression::Funcall { func, .. } => match func {
+                Intrinsic::Begin => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
     /// Determines whether this expression is "atomic" or not.  An
     /// atomic expression is one which is never split into two or more
     /// expressions.  For example, an expression containing an
@@ -380,7 +392,7 @@ impl Node {
     pub fn is_atomic(&self) -> bool {
         match self.e() {
             // Obvious fails
-            Expression::List(args) => false,
+            Expression::List(_) => false,
             Expression::Void => false,
             // Obvious passes
             Expression::Const(_) => true,


### PR DESCRIPTION
This puts in place additional layers of check to try and prevent wierd situations arising from the use of `for`.