### PR TITLE
fix: Unused Declaration for Array Columns (`define.go`)

### DIFF
--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -1562,13 +1562,18 @@ pub fn reduce(e: &AstNode, ctx: &mut Scope, settings: &CompileSettings) -> Resul
                     .and_then(|n| n.pure_eval().ok())
                     .and_then(|b| b.to_usize())
                     .ok_or_else(|| anyhow!("{:?} is not a valid index", index))?;
-                // Construct indexed handle
-                let ith_handle = handle.as_handle().ith(i.try_into().unwrap());
-                // Resolve it properly this time.
-                Ok(Some(
-                    ctx.resolve_symbol(&ith_handle.name)
-                        .with_context(|| make_ast_error(e))?,
-                ))
+                // Sanity check access within bounds
+                if domain.contains(i.try_into().unwrap()) {
+                    // Construct indexed handle
+                    let name = handle.as_handle().ith(i.try_into().unwrap()).to_string();
+                    // Resolve it properly this time.
+                    Ok(Some(
+                        ctx.resolve_symbol_with_path(&name)
+                            .with_context(|| make_ast_error(e))?,
+                    ))
+                } else {
+                    bail!("tried to access {} at index {}", symbol.pretty().bold(), i)
+                }
             } else {
                 bail!(anyhow!(
                     "{} of type {} is not indexable",

--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -1562,18 +1562,13 @@ pub fn reduce(e: &AstNode, ctx: &mut Scope, settings: &CompileSettings) -> Resul
                     .and_then(|n| n.pure_eval().ok())
                     .and_then(|b| b.to_usize())
                     .ok_or_else(|| anyhow!("{:?} is not a valid index", index))?;
-                if domain.contains(i.try_into().unwrap()) {
-                    Ok(Some(
-                        Node::column()
-                            .handle(handle.as_handle().ith(i))
-                            .kind(Kind::Commitment)
-                            .base(*base)
-                            .t(symbol.t().m())
-                            .build(),
-                    ))
-                } else {
-                    bail!("tried to access {} at index {}", symbol.pretty().bold(), i)
-                }
+                // Construct indexed handle
+                let ith_handle = handle.as_handle().ith(i.try_into().unwrap());
+                // Resolve it properly this time.
+                Ok(Some(
+                    ctx.resolve_symbol(&ith_handle.name)
+                        .with_context(|| make_ast_error(e))?,
+                ))
             } else {
                 bail!(anyhow!(
                     "{} of type {} is not indexable",

--- a/src/compiler/parser/definitions.rs
+++ b/src/compiler/parser/definitions.rs
@@ -97,7 +97,7 @@ fn reduce(e: &AstNode, ctx: &mut Scope, settings: &CompileSettings) -> Result<()
 
             for i in domain.iter() {
                 let ith_handle = handle.ith(i.try_into().unwrap());
-                ctx.insert_used_symbol(
+                ctx.insert_symbol(
                     &ith_handle.name,
                     Node::column()
                         .handle(ith_handle.clone())

--- a/src/compiler/tables.rs
+++ b/src/compiler/tables.rs
@@ -536,7 +536,7 @@ impl Scope {
         }
     }
 
-    fn resolve_symbol_with_path(&mut self, name: &str) -> Result<Node, symbols::Error> {
+    pub fn resolve_symbol_with_path(&mut self, name: &str) -> Result<Node, symbols::Error> {
         let components = name.split('.').collect::<Vec<_>>();
         self.root()._resolve_symbol_with_path(&components)
     }

--- a/src/structs/handle.rs
+++ b/src/structs/handle.rs
@@ -56,9 +56,20 @@ impl Handle {
     }
 
     pub fn to_string(&self) -> String {
-        match &self.perspective {
-            None => format!("{}.{}", self.module, self.name),
-            Some(p) => format!("{}.{}/{}", self.module, p, self.name),
+        // NOTE: its unclear why a distinction is needed for the
+        // prelude.
+        if self.module == "<prelude>" {
+            match &self.perspective {
+                // Generate cases
+                None => format!("{}", self.name),
+                Some(p) => format!("{}/{}", p, self.name),
+            }
+        } else {
+            match &self.perspective {
+                // Generate cases
+                None => format!("{}.{}", self.module, self.name),
+                Some(p) => format!("{}.{}/{}", self.module, p, self.name),
+            }
         }
     }
 

--- a/src/structs/handle.rs
+++ b/src/structs/handle.rs
@@ -55,6 +55,13 @@ impl Handle {
         }
     }
 
+    pub fn to_string(&self) -> String {
+        match &self.perspective {
+            None => format!("{}.{}", self.module, self.name),
+            Some(p) => format!("{}.{}/{}", self.module, p, self.name),
+        }
+    }
+
     pub fn maybe_with_perspective<S1: AsRef<str>, S2: AsRef<str>>(
         module: S1,
         name: S2,

--- a/src/transformer/ifs.rs
+++ b/src/transformer/ifs.rs
@@ -60,8 +60,10 @@ fn do_expand_ifs(e: &mut Node) -> Result<()> {
                 } else {
                     let conds = {
                         let cond_not_zero = cond.clone();
-                        let cond_zero = Intrinsic::Sub
-                            .unchecked_call(&[Node::one(), Intrinsic::Normalize.unchecked_call(&[cond.clone()])?])?;
+                        let cond_zero = Intrinsic::Sub.unchecked_call(&[
+                            Node::one(),
+                            Intrinsic::Normalize.unchecked_call(&[cond.clone()])?,
+                        ])?;
                         if if_not_zero {
                             [cond_not_zero, cond_zero]
                         } else {
@@ -168,7 +170,9 @@ fn raise_ifs(mut e: Node) -> Node {
                             }
                             // Repeat this until ifs pulled out
                             // from all argument positions.
-                            return raise_ifs(func_if.unchecked_call(&new_args).unwrap().with_type(a.t()));
+                            return raise_ifs(
+                                func_if.unchecked_call(&new_args).unwrap().with_type(a.t()),
+                            );
                         }
                     }
                     e


### PR DESCRIPTION
This puts through a fix for the generated `define.go` where certain unused columns were being turned into Go declarations.  Since these declarations were not then being used, Go was reporting an error (since it is very strict about this).