### PR TITLE
Rework generated "putters".

### DIFF
--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -11,7 +11,7 @@ use crossterm::{
 };
 use itertools::Itertools;
 use ratatui::{prelude::*, widgets::*};
-use ratatui::{TerminalOptions,Viewport};
+use ratatui::{TerminalOptions, Viewport};
 use regex_lite::Regex;
 use std::collections::HashMap;
 


### PR DESCRIPTION
This reworks the generate putters to use a more uniform style and, furthermore, to perform sanity checking on every value.  These now generates `Trace.java` files which write columns with the expected byte-width (e.g. `1` byte for `i8`, `2` bytes for `i16`, `4` bytes for `i32`) in all cases.