### PR TITLE
feat: Support `RON` and `JSON` bin formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ exporters = ["dep:handlebars"]
 inspector = ["dep:crossterm", "dep:ratatui", "dep:tui-textarea", "cli"]
 postgres = ["dep:postgres"]
 sqlite = ["dep:rusqlite"]
-json-bin = []
 
 [package.metadata.release]
 tag-prefix = ""

--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -1864,7 +1864,7 @@ pub(crate) fn reduce_toplevel(
         | Token::DefunAlias(..)
         | Token::DefConsts(..) => Ok(None),
         Token::DefPermutation { from, to, signs } => {
-            let froms = from
+            let froms: Vec<ColumnRef> = from
                 .iter()
                 .map(|from| {
                     if let Some(n) = reduce(from, ctx, settings)? {
@@ -1907,16 +1907,16 @@ pub(crate) fn reduce_toplevel(
                     signs: signs.clone(),
                 },
             )?;
-
+            // Determine suitably unique name for the permutation
+            // constraint.
+            let name = format!(
+                "{}_intrld_{}",
+                froms.iter().map(|f| f.as_handle().mangled_name()).join("_"),
+                tos.iter().map(|f| f.as_handle().mangled_name()).join("_"),
+            );
+            // Done
             Ok(Some(Constraint::Permutation {
-                handle: Handle::new(
-                    ctx.module(),
-                    format!(
-                        "{}_intrld_{}",
-                        froms.iter().map(|f| f.to_string()).join("_"),
-                        tos.iter().map(|f| f.to_string()).join("_"),
-                    ),
-                ),
+                handle: Handle::new(ctx.module(), name),
                 from: froms,
                 to: tos,
             }))

--- a/src/main.rs
+++ b/src/main.rs
@@ -952,14 +952,10 @@ fn main() -> Result<()> {
             std::fs::File::create(&outfile)
                 .with_context(|| format!("while creating `{}`", &outfile))?
                 .write_all(
-                    if json && cfg!(feature = "json-bin") {
-                        if pretty {
-                            serde_json::to_string_pretty(&constraints)?
-                        } else {
-                            serde_json::to_string(&constraints)?
-                        }
+                    if json && pretty {
+                        serde_json::to_string_pretty(&constraints)?
                     } else if json {
-                        panic!("Exporting as JSON requires the `json-bin` feature.");
+                        serde_json::to_string(&constraints)?
                     } else if pretty {
                         ron::ser::to_string_pretty(&constraints, ron::ser::PrettyConfig::default())?
                     } else {


### PR DESCRIPTION
Previously, the ability to generate `JSON` binfiles was hidden behind a build feature.  Hence, you needed to build the binary specifically for generating `JSON` binfiles.  The primary reason for this is that supporting both `RON` and `JSON` formats in the same binary required breaking changes to the format.  However, the time has come to address this and support both formats.  At this time, `RON` remains the default choice --- but this will be deprecated in the very near future.