### PR TITLE
feat: Support Perspective "blanking"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -894,6 +894,7 @@ fn main() -> Result<()> {
                 InspectorSettings {
                     open_module,
                     high_contrast,
+                    blank_perspectives: true,
                 },
             )
             .with_context(|| format!("while checking {}", tracefile.bright_white().bold()))?;


### PR DESCRIPTION
This completely hides values for columns in inactive perspectives. However, should one want to, the original behaviour can be toggled using 'p' for that module.