### PR TITLE
feat: Switch default `bin` format from `RON` to `JSON`

### DIFF
--- a/src/compiler/node.rs
+++ b/src/compiler/node.rs
@@ -4,7 +4,7 @@ use cached::Cached;
 use num_bigint::BigInt;
 use num_traits::{One, ToPrimitive, Zero};
 use owo_colors::{colored::Color, OwoColorize};
-use serde::de::{Error, Visitor};
+use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::write;
 use std::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,13 @@ pub struct Args {
     debug: bool,
 
     #[arg(
+        long,
+        help = "generate binfile as JSON instead of Rusty Object Notation (RON)",
+        global = true
+    )]
+    json: bool,
+
+    #[arg(
         short = 't',
         long = "threads",
         help = "number of threads to use",
@@ -387,12 +394,6 @@ enum Commands {
 
         #[arg(long, help = "human-readably serialize the constraint system")]
         pretty: bool,
-
-        #[arg(
-            long,
-            help = "generate output as JSON instead of in the Rusty Object Notation (RON)"
-        )]
-        json: bool,
     },
 }
 
@@ -415,17 +416,23 @@ impl ConstraintSetBuilder {
         }
     }
 
-    fn from_bin(filename: &str) -> Result<ConstraintSetBuilder> {
+    fn from_bin(json: bool, filename: &str) -> Result<ConstraintSetBuilder> {
+        // Read the constraint-set bin file
+        let contents = &std::fs::read_to_string(filename)
+            .with_context(|| anyhow!("while reading `{}`", filename))?;
+        // format.
+        let cs = if json {
+            serde_json::from_str(contents)
+                .with_context(|| anyhow!("while parsing `{}` (JSON)", filename))?
+        } else {
+            ron::from_str(contents)
+                .with_context(|| anyhow!("while parsing `{}` (RON)", filename))?
+        };
+        //
         Ok(ConstraintSetBuilder {
             debug: false,
             no_stdlib: false,
-            source: Either::Right(
-                ron::from_str(
-                    &std::fs::read_to_string(filename)
-                        .with_context(|| anyhow!("while reading `{}`", filename))?,
-                )
-                .with_context(|| anyhow!("while parsing `{}`", filename))?,
-            ),
+            source: Either::Right(cs),
             expand_to: Default::default(),
             auto_constraints: Default::default(),
         })
@@ -642,7 +649,7 @@ fn main() -> Result<()> {
             .unwrap_or(false)
     {
         info!("Loading `{}`", &args.source[0]);
-        ConstraintSetBuilder::from_bin(&args.source[0])?
+        ConstraintSetBuilder::from_bin(args.json, &args.source[0])?
     } else {
         info!("Parsing Corset source files...");
         let mut r = ConstraintSetBuilder::from_sources(args.no_stdlib, args.debug);
@@ -944,18 +951,14 @@ fn main() -> Result<()> {
                 }
             }
         }
-        Commands::Compile {
-            outfile,
-            pretty,
-            json,
-        } => {
+        Commands::Compile { outfile, pretty } => {
             let constraints = builder.into_constraint_set()?;
             std::fs::File::create(&outfile)
                 .with_context(|| format!("while creating `{}`", &outfile))?
                 .write_all(
-                    if json && pretty {
+                    if args.json && pretty {
                         serde_json::to_string_pretty(&constraints)?
-                    } else if json {
+                    } else if args.json {
                         serde_json::to_string(&constraints)?
                     } else if pretty {
                         ron::ser::to_string_pretty(&constraints, ron::ser::PrettyConfig::default())?

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,10 +63,10 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "generate binfile as JSON instead of Rusty Object Notation (RON)",
+        help = "generate binfile using Rusty Object Notation (RON) instead of JSON",
         global = true
     )]
-    json: bool,
+    ron: bool,
 
     #[arg(
         short = 't',
@@ -416,17 +416,17 @@ impl ConstraintSetBuilder {
         }
     }
 
-    fn from_bin(json: bool, filename: &str) -> Result<ConstraintSetBuilder> {
+    fn from_bin(ron: bool, filename: &str) -> Result<ConstraintSetBuilder> {
         // Read the constraint-set bin file
         let contents = &std::fs::read_to_string(filename)
             .with_context(|| anyhow!("while reading `{}`", filename))?;
         // format.
-        let cs = if json {
-            serde_json::from_str(contents)
-                .with_context(|| anyhow!("while parsing `{}` (JSON)", filename))?
-        } else {
+        let cs = if ron {
             ron::from_str(contents)
                 .with_context(|| anyhow!("while parsing `{}` (RON)", filename))?
+        } else {
+            serde_json::from_str(contents)
+                .with_context(|| anyhow!("while parsing `{}` (JSON)", filename))?
         };
         //
         Ok(ConstraintSetBuilder {
@@ -649,7 +649,7 @@ fn main() -> Result<()> {
             .unwrap_or(false)
     {
         info!("Loading `{}`", &args.source[0]);
-        ConstraintSetBuilder::from_bin(args.json, &args.source[0])?
+        ConstraintSetBuilder::from_bin(args.ron, &args.source[0])?
     } else {
         info!("Parsing Corset source files...");
         let mut r = ConstraintSetBuilder::from_sources(args.no_stdlib, args.debug);
@@ -956,14 +956,14 @@ fn main() -> Result<()> {
             std::fs::File::create(&outfile)
                 .with_context(|| format!("while creating `{}`", &outfile))?
                 .write_all(
-                    if args.json && pretty {
-                        serde_json::to_string_pretty(&constraints)?
-                    } else if args.json {
-                        serde_json::to_string(&constraints)?
-                    } else if pretty {
+                    if args.ron && pretty {
                         ron::ser::to_string_pretty(&constraints, ron::ser::PrettyConfig::default())?
-                    } else {
+                    } else if args.ron {
                         ron::ser::to_string(&constraints)?
+                    } else if pretty {
+                        serde_json::to_string_pretty(&constraints)?
+                    } else {
+                        serde_json::to_string(&constraints)?
                     }
                     .as_bytes(),
                 )

--- a/src/structs/handle.rs
+++ b/src/structs/handle.rs
@@ -1,6 +1,5 @@
-use serde::de::{Error, Visitor};
+use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
 
 use crate::{compiler::MAIN_MODULE, utils::purify};
 


### PR DESCRIPTION
This switches over the default format for the `bin` files from using Rusty Object Notation (RON) to JSON.