### PR TITLE
fix: Update `check` reporting for perspectives

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -149,12 +149,22 @@ fn fail(
             .sorted_by_key(|h| cs.handle(h).name.clone())
             .collect::<Vec<_>>()
     };
-
+    // Determine max perspective length
+    let mut max_perspective_len = 0;
+    for h in &handles {
+        if let Some(p) = &cs.handle(h).perspective {
+            max_perspective_len = max_perspective_len.max(p.len());
+        }
+    }
+    //
     let mut m_columns = vec![vec![String::new()]
         .into_iter()
-        .chain(handles.iter().map(|h| cs.handle(h).name.to_string()))
+        .chain(
+            handles
+                .iter()
+                .map(|h| to_column_name(cs.handle(h), max_perspective_len)),
+        )
         .collect::<Vec<_>>()];
-
     let (eval_columns_range, idx_highlight) = if wrap {
         (
             (i - settings.context_span_before)..=i + settings.context_span_after,
@@ -576,5 +586,12 @@ pub fn check(
                 .collect::<Vec<_>>()
                 .join(", ")
         )
+    }
+}
+
+fn to_column_name(h: &Handle, max_perspective: usize) -> String {
+    match &h.perspective {
+        Some(p) => format!("{} {}", p, h.name),
+        None => format!("{:width$} {}", "", h.name, width = max_perspective),
     }
 }

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -21,20 +21,6 @@ impl Model {
     const MIN_ELEMENT: isize = -1;
     const MAX_ELEMENT: isize = 1;
 
-    pub fn new(
-        name: &'static str,
-        cols: &'static [&'static str],
-        limit: usize,
-        oracle: Option<fn(data: &Trace) -> bool>,
-    ) -> Self {
-        Self {
-            name,
-            cols,
-            limit,
-            oracle,
-        }
-    }
-
     /// Generate all traces matching the model configuration upto
     /// length `n`, and split them into the `accepts` and `rejects`.
     /// The former are those traces which are expected to pass, whilst
@@ -304,7 +290,7 @@ fn shift_3_oracle(tr: &Trace) -> bool {
 
 #[allow(non_snake_case)]
 fn shift_5_oracle(tr: &Trace) -> bool {
-    let (A, B, C) = (tr.col("A"), tr.col("B"), tr.col("C"));
+    let (A, C) = (tr.col("A"), tr.col("C"));
 
     for k in 0..tr.height() {
         let c1 = k < 4 || A[k - 4] == 0;


### PR DESCRIPTION
This updates the reporting for the `check` command with respect to perspectives.  Specifically, the output now resembles that of the inspector more closely by including perspective identifiers when relevant.