### PR TITLE
Updating release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.4
+        uses: rust-build/rust-build.action@v1.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+	  RUSTFLAGS: --locked
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,8 @@ jobs:
       with:
           rustflags: ""
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -vv --locked
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -v --locked
       env:
         CORSET_TEST_LIMIT: 4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "corset"
-version = "9.7.12"
+version = "9.7.13"
 dependencies = [
  "anyhow",
  "ark-bls12-377",


### PR DESCRIPTION
This updates the release action to include the `--locked` flag.  This shold prevent clashes as new versions of upstream libraries are released.