### PR TITLE
fix: Update Github Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Compile and release
-        uses: rust-build/rust-build.action@v1.4.4
+        uses: rust-build/rust-build.action@v1.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXTRA_COMMAND_FLAGS: --locked
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,8 +20,8 @@ jobs:
       with:
           rustflags: ""
     - name: Build
-      run: cargo build --verbose
+      run: cargo build -vv
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test -v
       env:
         CORSET_TEST_LIMIT: 4


### PR DESCRIPTION
This updatest the github `release.yml` action to support the latest version of Rust.  This is required for the ratatui dependency.  At this stage, I did not figure out how to "lock" the dependencies for the release build.