### PR TITLE
Remove `--locked` from `release` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: rust-build/rust-build.action@v1.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXTRA_COMMAND_FLAGS: --locked
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}


### PR DESCRIPTION
This removes the `--locked` directive from the `release` action build because, despite several attempts, I cannot get this to work.