### PR TITLE
Remove vector operations

### DIFF
--- a/src/compiler/tables.rs
+++ b/src/compiler/tables.rs
@@ -54,10 +54,10 @@ lazy_static::lazy_static! {
             handle: Handle::new(super::MAIN_MODULE, "shift"),
             class: FunctionClass::Builtin(Builtin::Shift),
         },
-        "~>>" => Function{
-            handle: Handle::new(super::MAIN_MODULE, "~>>"),
-            class: FunctionClass::Builtin(Builtin::NormFlat),
-        },
+        // "~>>" => Function{
+        //     handle: Handle::new(super::MAIN_MODULE, "~>>"),
+        //     class: FunctionClass::Builtin(Builtin::NormFlat),
+        // },
         "if" => Function {
             handle: Handle::new(super::MAIN_MODULE, "if"),
             class: FunctionClass::Builtin(Builtin::If)
@@ -76,18 +76,18 @@ lazy_static::lazy_static! {
             handle: Handle::new(super::MAIN_MODULE, "-"),
             class: FunctionClass::Intrinsic(Intrinsic::Sub)
         },
-        "+." => Function {
-            handle: Handle::new(super::MAIN_MODULE, "+"),
-            class: FunctionClass::Intrinsic(Intrinsic::VectorAdd)
-        },
-        "*." => Function {
-            handle: Handle::new(super::MAIN_MODULE, "*"),
-            class: FunctionClass::Intrinsic(Intrinsic::VectorMul)
-        },
-        "-." => Function {
-            handle: Handle::new(super::MAIN_MODULE, "-"),
-            class: FunctionClass::Intrinsic(Intrinsic::VectorSub)
-        },
+        // "+." => Function {
+        //     handle: Handle::new(super::MAIN_MODULE, "+"),
+        //     class: FunctionClass::Intrinsic(Intrinsic::VectorAdd)
+        // },
+        // "*." => Function {
+        //     handle: Handle::new(super::MAIN_MODULE, "*"),
+        //     class: FunctionClass::Intrinsic(Intrinsic::VectorMul)
+        // },
+        // "-." => Function {
+        //     handle: Handle::new(super::MAIN_MODULE, "-"),
+        //     class: FunctionClass::Intrinsic(Intrinsic::VectorSub)
+        // },
         "~" => Function {
             handle: Handle::new(super::MAIN_MODULE, "~"),
             class: FunctionClass::Intrinsic(Intrinsic::Normalize)

--- a/src/stdlib.lisp
+++ b/src/stdlib.lisp
@@ -34,7 +34,7 @@
 
 (defpurefun ((not :binary@bool :force) (x :binary)) (- 1 x))
 
-(defpurefun ((eq! :@loob :force) x y) (~>> (-. x y)))
+(defpurefun ((eq! :@loob :force) x y) (~ (- x y)))
 (defpurefun ((neq! :binary@loob :force) x y) (not (~ (eq! x y))))
 (defunalias = eq!)
 


### PR DESCRIPTION
This removes all of the vector operations since they are not used, and have subtle bugs.