### PR TITLE
Fix `Trace.java` template

### DIFF
--- a/src/exporters/besu_trace_columns.java
+++ b/src/exporters/besu_trace_columns.java
@@ -17,6 +17,7 @@ package net.consensys.linea.zktracer.module.{{ module }};
 
 import java.math.BigInteger;
 import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 
@@ -43,10 +44,11 @@ public class Trace {
   {{/each}}
 
   static List<ColumnHeader> headers(int length) {
-    return List.of(
-        {{ #each registers }}
-        new ColumnHeader("{{ this.corset_name }}", {{ this.bytes_width }}, length){{ #if @last }});{{ else }},{{ /if }}
-        {{ /each }}
+      List<ColumnHeader> headers = new ArrayList<>();
+      {{ #each registers }}
+      headers.add(new ColumnHeader("{{ this.corset_name }}", {{ this.bytes_width }}, length));
+      {{ /each }}
+      return headers;
   }
 
   public Trace(List<MappedByteBuffer> buffers) {


### PR DESCRIPTION
This fixes the `Trace.java` template for modules which have no columns. Previously, this was generating malformed java in that case.