### PR TITLE
Support custom class name for trace file.

### DIFF
--- a/src/exporters/besu.rs
+++ b/src/exporters/besu.rs
@@ -46,6 +46,7 @@ struct BesuConstant {
 }
 #[derive(Serialize)]
 struct TemplateData {
+    class: String,
     module: String,
     module_prefix: String,
     columns: Vec<BesuColumn>,
@@ -201,7 +202,12 @@ fn perspectivize_name(h: &Handle, p: &str) -> String {
     )
 }
 
-pub fn render(cs: &ConstraintSet, package: &str, output_path: Option<&String>) -> Result<()> {
+pub fn render(
+    cs: &ConstraintSet,
+    package: &str,
+    class: &str,
+    output_path: Option<&String>,
+) -> Result<()> {
     let registers = cs
         .columns
         .registers
@@ -277,6 +283,7 @@ pub fn render(cs: &ConstraintSet, package: &str, output_path: Option<&String>) -
     handlebars.register_escape_fn(handlebars::no_escape);
 
     let template_data = TemplateData {
+        class: class.to_owned(),
         module: package.to_owned(),
         module_prefix: package.to_case(Case::Pascal),
         constants,
@@ -294,7 +301,7 @@ pub fn render(cs: &ConstraintSet, package: &str, output_path: Option<&String>) -
                 bail!("{} is not a directory", f.bold().yellow());
             }
 
-            let trace_columns_java_filepath = Path::new(f).join("Trace.java");
+            let trace_columns_java_filepath = Path::new(f).join(format!("{class}.java"));
 
             File::create(&trace_columns_java_filepath)?
                 .write_all(trace_columns_render.as_bytes())

--- a/src/exporters/besu_trace_columns.java
+++ b/src/exporters/besu_trace_columns.java
@@ -31,7 +31,7 @@ import org.apache.tuweni.bytes.Bytes;
  * <p>Any modifications to this code may be overwritten and could lead to unexpected behavior.
  * Please DO NOT ATTEMPT TO MODIFY this code directly.
  */
-public class Trace {
+public class {{ class }} {
   {{#each constants}}
   public static final {{ this.tupe }} {{ this.name }} = {{ this.value }};
   {{/each}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,14 @@ enum Commands {
         )]
         package: String,
 
+        #[arg(
+            short = 'c',
+            long = "class",
+            default_value = "Trace",
+            help = "class name for generated trace file"
+        )]
+        class: String,
+
         #[arg(short = 'o', long = "out", help = "where to render the columns")]
         output_file_path: Option<String>,
     },
@@ -674,11 +682,13 @@ fn main() -> Result<()> {
         #[cfg(feature = "exporters")]
         Commands::Besu {
             package,
+            class,
             output_file_path: output_path,
         } => {
             exporters::besu::render(
                 &builder.into_constraint_set()?,
                 &package,
+                &class,
                 output_path.as_ref(),
             )?;
         }


### PR DESCRIPTION
This allows a custom class name to be used in place of `Trace.java` when desired.