### PR TITLE
feat: support filtering of perspectives

### DIFF
--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -124,12 +124,11 @@ impl ModuleView {
             .iter()
             .enumerate()
             .filter_map(|(i, (_, handle))| {
-                if self.regexps.is_empty()
-                    || self
-                        .regexps
+                if self.regexps.is_empty() || {
+                    self.regexps
                         .iter()
-                        .any(|regex| regex.is_match(&handle.name))
-                {
+                        .any(|regex| regex.is_match(&handle.to_string()))
+                } {
                     Some(i)
                 } else {
                     None


### PR DESCRIPTION
This enables filtering to include the perspective as part of the filter. In essence, the change is that the filter regex now runs over the full column name (including perspective and module) rather than just the name.