### PR TITLE
feat: Allow empty `(begin ..)`

### DIFF
--- a/src/compiler/generator.rs
+++ b/src/compiler/generator.rs
@@ -251,7 +251,7 @@ impl FuncVerifier<Node> for Intrinsic {
             Intrinsic::Neg => Arity::Monadic,
             Intrinsic::Inv => Arity::Monadic,
             Intrinsic::Normalize => Arity::Monadic,
-            Intrinsic::Begin => Arity::AtLeast(1),
+            Intrinsic::Begin => Arity::AtLeast(0),
             Intrinsic::IfZero | Intrinsic::IfNotZero => Arity::Between(2, 3),
         }
     }


### PR DESCRIPTION
This adjusts the minimum expected arity for `begin` statements to allow them to be empty.  The reason for this is that, in practice, we may have a `begin` statement stuffed only with `debug` constraints (which are physically removed unless the `--debug` switch is provided).