### PR TITLE
fix: column setters in trace template

### DIFF
--- a/src/exporters/besu.rs
+++ b/src/exporters/besu.rs
@@ -21,6 +21,7 @@ const TRACE_COLUMNS_TEMPLATE: &str = include_str!("besu_trace_columns.java");
 
 #[derive(Serialize)]
 struct BesuColumn {
+    class: String,
     corset_name: String,
     java_name: String,
     appender: String,
@@ -240,6 +241,7 @@ pub fn render(
                 let r = c.register.unwrap();
                 let register = reg_to_string(&cs.columns.registers[r], r).to_case(Case::Camel);
                 Some(BesuColumn {
+                    class: class.to_owned(),
                     corset_name: c.handle.to_string(),
                     java_name: c.handle.name.to_case(Case::Camel),
                     appender: handle_to_appender(&c.handle),

--- a/src/exporters/besu_trace_columns.java
+++ b/src/exporters/besu_trace_columns.java
@@ -31,7 +31,7 @@ import org.apache.tuweni.bytes.Bytes;
  * <p>Any modifications to this code may be overwritten and could lead to unexpected behavior.
  * Please DO NOT ATTEMPT TO MODIFY this code directly.
  */
-public class {{ class }} {
+public class {{ this.class }} {
   {{#each constants}}
   public static final {{ this.tupe }} {{ this.name }} = {{ this.value }};
   {{/each}}
@@ -51,7 +51,7 @@ public class {{ class }} {
       return headers;
   }
 
-  public {{ class }} (List<MappedByteBuffer> buffers) {
+  public {{ this.class }} (List<MappedByteBuffer> buffers) {
     {{ #each registers }}
     this.{{ java_name }} = buffers.get({{ @index }});
     {{ /each }}
@@ -66,7 +66,7 @@ public class {{ class }} {
   }
 
   {{#each columns}}
-  public {{ class }} {{ this.appender }}(final {{ this.tupe }} b) {
+  public {{ this.class }} {{ this.appender }}(final {{ this.tupe }} b) {
     if (filled.get({{ this.reg_id }})) {
       throw new IllegalStateException("{{ this.corset_name }} already set");
     } else {
@@ -79,7 +79,7 @@ public class {{ class }} {
   }
 
   {{/each}}
-  public {{ class }} validateRow() {
+  public {{ this.class }} validateRow() {
     {{#each registers}}
     if (!filled.get({{ this.id }})) {
       throw new IllegalStateException("{{ this.corset_name }} has not been filled");
@@ -92,7 +92,7 @@ public class {{ class }} {
     return this;
   }
 
-  public {{ class }} fillAndValidateRow() {
+  public {{ this.class }} fillAndValidateRow() {
     {{#each registers}}
     if (!filled.get({{ this.id }})) {
       {{ this.java_name }}.position({{ this.java_name }}.position() + {{ this.bytes_width }});


### PR DESCRIPTION
The generated column setters were invalid because they were iterating over BesuColumn instances which didn't (previously) include the `class` attribute.