### PR TITLE
Support Checking for Negative Domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "corset"
-version = "9.7.15"
+version = "9.7.16"
 dependencies = [
  "anyhow",
  "ark-bls12-377",

--- a/src/check.rs
+++ b/src/check.rs
@@ -193,7 +193,6 @@ fn fail(
                 .collect(),
         )
     }
-
     let mut trace = String::new();
     for ii in 0..m_columns[0].len() {
         for (j, col) in m_columns.iter().enumerate() {
@@ -218,7 +217,6 @@ fn fail(
         trace.push('\n');
     }
     trace.push('\n');
-
     bail!(
         trace
             + &expr.debug(
@@ -299,7 +297,16 @@ fn check_constraint(
     match domain {
         Some(is) => {
             for i in is.iter() {
-                check_constraint_at(cs, expr, i, true, true, &mut cache, settings)?;
+                let err = check_constraint_at(cs, expr, i, true, true, &mut cache, settings)
+                    .map_err(|e| CheckingError::FailingConstraint(name.clone(), e.to_string()));
+
+                if err.is_err() {
+                    if settings.continue_on_error {
+                        eprintln!("{:?}", err);
+                    } else {
+                        bail!(err.err().unwrap());
+                    }
+                }
             }
         }
         None => {

--- a/src/column.rs
+++ b/src/column.rs
@@ -645,10 +645,11 @@ impl ValueBacking {
                 if i < 0 {
                     if wrap {
                         let new_i = v.len() as isize + i;
-                        if new_i < 0 || new_i >= v.len() as isize {
-                            panic!("abnormal wrapping value {}", new_i)
+                        if new_i < 0 {
+                            Some(v.get(0).unwrap())
+                        } else {
+                            v.get(new_i as usize)
                         }
-                        v.get((v.len() as isize + i) as usize)
                     } else if i < -spilling {
                         Some(v.get(0).unwrap())
                     } else {


### PR DESCRIPTION
Previously, there was no proper checking for failing constraints when the domain of the constraint was `-1`.  This is an unexpected bug within the tool.