### PR TITLE
fix: remove unwraps in the function when parsing a trace

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -663,12 +663,12 @@ impl ValueBacking {
                     if wrap {
                         let new_i = v.len() as isize + i;
                         if new_i < 0 {
-                            Some(v.get(0).unwrap())
+                            v.get(0)
                         } else {
                             v.get(new_i as usize)
                         }
                     } else if i < -spilling {
-                        Some(v.get(0).unwrap())
+                        v.get(0)
                     } else {
                         v.get((i + spilling) as usize)
                     }


### PR DESCRIPTION
## Why
When parsing a trace, there could be a chance when `ValueBacking` of column registers is `None`. This situation is handled in `determine_column_padding` function ([here](https://github.com/Consensys/corset/blob/master/src/cgo.rs#L171)). However, `get()` method that is used to get internal `Value` uses unwraps which may cause a panic.

## What
Since `None` case is already handled in `determine_column_padding` function, we can freely get rid from unwraps.